### PR TITLE
Update to getting started guide, aimed at issue 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Files for git to ignore
+
+# Certain editors
+*.swp
+\#*
+*~
+

--- a/pi/booting-logging-in.md
+++ b/pi/booting-logging-in.md
@@ -9,18 +9,18 @@ The Raspberry Pi does not have an on or off switch. To power on your Pi:
 
 1. Once your Raspberry Pi has completed the boot process, it will usually log you in to the graphical user interface (desktop) for user `pi`.
 
-1. On old versions of Raspbian, or if you changed these settings in the Raspberry Pi Configuration tool, you may need to do the following steps. 
+1. On old versions of Raspbian, or if you changed what happens on start-up in the Raspberry Pi Configuration tool, you may need to do the following steps. 
 
-1. A login prompt may appear. 
-
-  The default login for Raspbian is username `pi` with the password `raspberry`. 
-  *Note you will not see any writing appear when you type the password. This is a security feature in Linux.*
-
-1. After you have successfully logged in, you may see the command line prompt 
-
-  ```bash
-  pi@raspberrypi~$
-  ```
-  This lets you know that you are logged into your Pi. From here you can interact with your computer using only text commands. See [The Command Line](command-line-guide.md) guide to learn more.
-
-1. To load the graphical user interface, type `startx` and press `Enter` on your keyboard.
+  1. A login prompt may appear. 
+  
+    The default login for Raspbian is username `pi` with the password `raspberry`. 
+    *Note you will not see any writing appear when you type the password. This is a security feature in Linux.*
+  
+  1. After you have successfully logged in, you may see the command line prompt 
+  
+    ```bash
+    pi@raspberrypi~$
+    ```
+    This lets you know that you are logged into your Pi. From here you can interact with your computer using only text commands. See [The Command Line](command-line-guide.md) guide to learn more.
+  
+  1. To load the graphical user interface, type `startx` and press `Enter` on your keyboard.

--- a/pi/booting-logging-in.md
+++ b/pi/booting-logging-in.md
@@ -7,12 +7,16 @@ The Raspberry Pi does not have an on or off switch. To power on your Pi:
 
   *Note that if you do not see any text on your screen, it may be because you did not turn it on before powering up your Raspberry Pi.*
 
-1. Once your Raspberry Pi has completed the boot process, a login prompt will appear. 
+1. Once your Raspberry Pi has completed the boot process, it will usually log you in to the graphical user interface (desktop) for user `pi`.
+
+1. On old versions of Raspbian, or if you changed these settings in the Raspberry Pi Configuration tool, you may need to do the following steps. 
+
+1. A login prompt may appear. 
 
   The default login for Raspbian is username `pi` with the password `raspberry`. 
   *Note you will not see any writing appear when you type the password. This is a security feature in Linux.*
 
-1. After you have successfully logged in, you will see the command line prompt 
+1. After you have successfully logged in, you may see the command line prompt 
 
   ```bash
   pi@raspberrypi~$

--- a/pi/quick-pi-setup.md
+++ b/pi/quick-pi-setup.md
@@ -51,6 +51,6 @@ Before you plug anything into your Raspberry Pi, make sure that you have all the
 
 ## What's next?
 
-- [Log into your Raspberry Pi](botting-logging-in.md)
+- [Log into your Raspberry Pi](booting-logging-in.md)
 
 

--- a/pi/writing-sd-card-image.md
+++ b/pi/writing-sd-card-image.md
@@ -23,14 +23,16 @@ It is best to format your SD card before copying the NOOBS files onto it. To do 
 
 ## Drag and drop NOOBS files
 
-1. Once your SD card has been formatted, drag all the files in the extracted NOOBS folder and drop them onto the SD card drive.
-1. The necessary files will then be transferred to your SD card.
+ 1. The necessary files will then be transferred to your SD card.
 1. When this process has finished, safely remove the SD card and insert it into your Raspberry Pi.
 
 ## First time you power on
 
 1. Plug in your keyboard, mouse and monitor  cables.
 1. Now plug in the USB power cable to your Pi.
-1. Your Raspberry Pi will boot, and a window will appear with a list of different operating systems that you can install. We recommend that you use Raspbian – tick the box next to Raspbian and click on `Install`.
+1. Your Raspberry Pi will boot, and a window will appear with a list of different operating systems that you can install. We recommend that you use Raspbian – tick the box next to Raspbian and click on `Install`. (If you do not have a connection to the Internet, Raspbian is the only option.)
 1. Raspbian will then run through its installation process. *Note this can take a while.*
-1. When the install process has completed, the Raspberry Pi configuration menu (`raspi-config`) will load. Here you are able to set the time and date for your region and enable a Raspberry Pi camera board, or even create users. You can exit this menu by using `Tab` on your keyboard to move to `Finish`.
+1. When the installation is complete, and you click on OK, you will be logged in to the graphical user interface (desktop) as user `pi`. From here, you can explore everything!
+1. But first, go to the Menu (top left) and navigate through Preferences... to the Raspberry Pi Configuration tool. Here you are able to tell Raspbian what region you are in, set your password, change what happens when Raspbian starts, or enable a Raspberry Pi camera board.
+1. If the time or date are wrong, you can correct them here too. Any time you have a connection to the Internet, Raspbian should correct them automatically.
+

--- a/pi/writing-sd-card-image.md
+++ b/pi/writing-sd-card-image.md
@@ -23,7 +23,8 @@ It is best to format your SD card before copying the NOOBS files onto it. To do 
 
 ## Drag and drop NOOBS files
 
- 1. The necessary files will then be transferred to your SD card.
+1. Once your SD card has been formatted, drag all the files in the extracted NOOBS folder and drop them onto the SD card drive.
+1. The necessary files will then be transferred to your SD card.
 1. When this process has finished, safely remove the SD card and insert it into your Raspberry Pi.
 
 ## First time you power on
@@ -33,6 +34,10 @@ It is best to format your SD card before copying the NOOBS files onto it. To do 
 1. Your Raspberry Pi will boot, and a window will appear with a list of different operating systems that you can install. We recommend that you use Raspbian – tick the box next to Raspbian and click on `Install`. (If you do not have a connection to the Internet, Raspbian is the only option.)
 1. Raspbian will then run through its installation process. *Note this can take a while.*
 1. When the installation is complete, and you click on OK, you will be logged in to the graphical user interface (desktop) as user `pi`. From here, you can explore everything!
-1. But first, go to the Menu (top left) and navigate through Preferences... to the Raspberry Pi Configuration tool. Here you are able to tell Raspbian what region you are in, set your password, change what happens when Raspbian starts, or enable a Raspberry Pi camera board.
-1. If the time or date are wrong, you can correct them here too. Any time you have a connection to the Internet, Raspbian should correct them automatically.
+1. First, go to the Menu (top left) and navigate through "Preferences" to the Raspberry Pi Configuration tool. Here you might need to:
+  1. Under "Localisation", tell Raspbian what region and time zone you are in (especially if you are not in Great Britain).
+  1. Change what happens when Raspbian starts, e.g. so it asks for a password.
+  1. Set your password, to stop anyone else logging in as `pi`.
+  1. Enable a Raspberry Pi camera board.
+  1. Set the time and date if they are wrong (if Raspbian cannot get them from the Internet).
 


### PR DESCRIPTION
Hey all. I noticed the divergence (issue #9) between the guide, at https://www.raspberrypi.org/help/noobs-setup/, and my actual experience. This has been remarked on in the forums too. The text seems to be from your repo.

I offer you these changes to better reflect the current versions of NOOBS and Raspbian. The user is no longer led to expect raspi-config to step in during the first boot, and is shown where to find the graphical equivalent, for setting timezone, etc..
